### PR TITLE
fix: bastion name use the variable

### DIFF
--- a/module.tf
+++ b/module.tf
@@ -1,5 +1,5 @@
 resource "azurerm_bastion_host" "azurebastion" {
-  name                = var.bastion_config.name
+  name                = var.name
   location            = var.location
   resource_group_name = var.resource_group_name
   tags                = var.tags


### PR DESCRIPTION
This bug came from the the caf fundation project that use a object named "bastion_config"